### PR TITLE
feat: 파일 유효성 검사 로직 추가, 새로운 파일 등록 시 id 추가 및 재가공

### DIFF
--- a/src/pages/admin/notice/write.css
+++ b/src/pages/admin/notice/write.css
@@ -1,23 +1,3 @@
-/** HEADER  */
-.write-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-
-  border-bottom: 1px solid #e1e1e1;
-
-  padding: 2.1rem 0;
-}
-
-.write-header h1 {
-  margin: 0;
-  margin-left: 2.4rem;
-  font-size: 2.4rem;
-
-  font-weight: 700;
-  line-height: 29px;
-}
-
 .button {
   margin-right: 2.4rem;
 }


### PR DESCRIPTION
## ⚾️ Related Issues

- close #14

## 📝 Task Details

- 파일 유효성 검사 로직 추가하여 모달 표시
- 새로운 파일 등록 시에 id 1번으로 제공 및 나머지 공지들이 id 1씩 뒤로 미룸

## 📂 References

파일 크기를 초과하는 경우
![image](https://github.com/user-attachments/assets/d11c366d-b9e8-4ebe-8edb-c2b5bd400b0d)
파일 개수를 초과하는 경우
![image](https://github.com/user-attachments/assets/8f07b231-8a81-40e7-b14c-cc934b918f24)
허용되지 않은 형식일 경우
![image](https://github.com/user-attachments/assets/1caab993-6520-4f8b-8b20-0cc9aafd9e3c)


## 💕 Review Requirements

- 새로운 파일 등록 시에 유진님처럼 id를 사용하지 않고 배열의 인덱스를 활용하는 법도 있긴 하더라고요! 
저는 각 공지사항에 대한 고유식별자가 존재하는게 나을 것 같아서 일단 id로 관리하였습니다!
